### PR TITLE
Reintroduce previously removed channel funding and aliasing functionality in gLightning

### DIFF
--- a/gbitcoin/bitcoind.go
+++ b/gbitcoin/bitcoind.go
@@ -732,3 +732,29 @@ func ConvertBtc(btc float64) uint64 {
 	}
 	return uint64(sat)
 }
+
+type CreateWalletRequest struct {
+	WalletName         string `json:"wallet_name"`
+	DisablePrivateKeys *bool  `json:"disable_private_keys,omitempty"`
+	Blank              *bool  `json:"blank,omitempty"`
+	Passphrase         string `json:"passphrase"`
+	AvoidReuse         *bool  `json:"avoid_reuse,omitempty"`
+	Descriptors        *bool  `json:"descriptors,omitempty"`
+	LoadOnStartup      *bool  `json:"load_on_startup,omitempty"`
+}
+
+func (r *CreateWalletRequest) Name() string {
+	return "createwallet"
+}
+
+type CreateWalletResponse struct {
+	Name    string `json:"name"`
+	Warning string `json:"warning"`
+}
+
+func (b *Bitcoin) CreateWallet(req *CreateWalletRequest) (*CreateWalletResponse, error) {
+	var resp CreateWalletResponse
+	err := b.request(req, &resp)
+
+	return &resp, err
+}


### PR DESCRIPTION

- Add 'ChannelAlias' structure for local and remote aliases in a peer channel.
- Include additional fields in 'FundChannelRequest' and 'FundChannelResult' structures.
- Include the CreateWallet function with its corresponding 'CreateWalletRequest' and 'CreateWalletResponse'
- Adjust all 'FundChannel' related functions to accommodate these new fields."
- The tests were not fixed